### PR TITLE
Fix ruby keyword parameter deprecation warnings

### DIFF
--- a/lib/pathutil.rb
+++ b/lib/pathutil.rb
@@ -456,14 +456,10 @@ class Pathutil
     to   = self.class.new(to)
 
     if directory?
-      safe_copy_directory(to, {
-        :root => root, :ignore => ignore
-      })
+      safe_copy_directory(to, root: root, ignore: ignore)
 
     else
-      safe_copy_file(to, {
-        :root => root
-      })
+      safe_copy_file(to, root: root)
     end
   end
 
@@ -494,14 +490,10 @@ class Pathutil
     kwd[:encoding] ||= encoding
 
     if normalize[:read]
-      File.read(self, *args, kwd).encode({
-        :universal_newline => true
-      })
+      File.read(self, *args, **kwd).encode(universal_newline: true)
 
     else
-      File.read(
-        self, *args, kwd
-      )
+      File.read(self, *args, **kwd)
     end
   end
 
@@ -534,13 +526,13 @@ class Pathutil
     kwd[:encoding] ||= encoding
 
     if normalize[:read]
-      File.readlines(self, *args, kwd).encode({
+      File.readlines(self, *args, **kwd).encode({
         :universal_newline => true
       })
 
     else
       File.readlines(
-        self, *args, kwd
+        self, *args, **kwd
       )
     end
   end
@@ -556,11 +548,11 @@ class Pathutil
     if normalize[:write]
       File.write(self, data.encode(
         :crlf_newline => true
-      ), *args, kwd)
+      ), *args, **kwd)
 
     else
       File.write(
-        self, data, *args, kwd
+        self, data, *args, **kwd
       )
     end
   end
@@ -670,9 +662,7 @@ class Pathutil
   private
   def safe_copy_file(to, root: nil)
     raise Errno::EPERM, "#{self} not in #{root}" unless in_path?(root)
-    FileUtils.cp(self, to, {
-      :preserve => true
-    })
+    FileUtils.cp(self, to, preserve: true)
   end
 
   # --
@@ -697,15 +687,11 @@ class Pathutil
             }"
 
           elsif file.file?
-            FileUtils.cp(file, to, {
-              :preserve => true
-            })
+            FileUtils.cp(file, to, preserve: true)
 
           else
             path = file.realpath
-            path.safe_copy(to.join(file.basename), {
-              :root => root, :ignore => ignore
-            })
+            path.safe_copy(to.join(file.basename), root: root, ignore: ignore)
           end
         end
       end

--- a/spec/tests/lib/pathutil/helpers_spec.rb
+++ b/spec/tests/lib/pathutil/helpers_spec.rb
@@ -76,9 +76,7 @@ describe Pathutil::Helpers do
           #
 
           after do
-            described_class.load_yaml("hello: world", {
-              :aliases => true
-            })
+            described_class.load_yaml("hello: world", aliases: true)
           end
         end
 

--- a/spec/tests/lib/pathutil_spec.rb
+++ b/spec/tests/lib/pathutil_spec.rb
@@ -944,9 +944,7 @@ describe Pathutil do
 
     context "with an encoding argument" do
       before do
-        file.write("hello", {
-          :encoding => "ASCII"
-        })
+        file.write("hello", encoding: "ASCII")
       end
 
       #
@@ -1050,11 +1048,10 @@ describe Pathutil do
           name1.join(name2.basename, name1.basename).touch
           name1.join(name1.basename).touch
 
-          name1.safe_copy(name2, {
-            :root => tmpdir1, :ignore => [
+          name1.safe_copy(name2, root: tmpdir1, ignore: [
               name1.join(name2.basename, name1.basename)
             ]
-          })
+          )
         end
 
         #
@@ -1077,9 +1074,7 @@ describe Pathutil do
           name1.join(name2.basename, name1.basename).touch
           name1.join(name1.basename).touch
 
-          name1.safe_copy(name2, {
-            :root => tmpdir1
-          })
+          name1.safe_copy(name2, root: tmpdir1)
         end
 
         #


### PR DESCRIPTION
In ruby 2.7, using the last argument as keyword parameters became
deprecated in preparation for ruby 3.0. When running the tests, we saw
numerous deprecation warnings. This commit fixes up those deprecation
warnings by explicitly passing the last argument(s) as keyword
argument(s).

See: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Fixes #4

Side note: this commit did not fix the `#binread` method because it was
untested, and when attempting to add tests, we got the following failing
test:

```
1) Pathutil#binread when set to normalize should use encode to convert CRLF to LF
   Failure/Error:
     File.binread(self, *args, kwd).encode({
       :universal_newline => true
     })

   TypeError:
     no implicit conversion of Hash into Integer
   # ./lib/pathutil.rb:509:in `binread'
   # ./lib/pathutil.rb:509:in `binread'
   # ./spec/tests/lib/pathutil_spec.rb:943:in `block (4 levels) in <top (required)>'
```

...which appears to be occuring because of an interface mismatch as
`IO#binread` does not take keyword arguments.

https://ruby-doc.org/core-2.7.1/IO.html#method-c-binread

- [x] I have added or updated the specs/tests.
- [x] I have verified that the specs/tests pass on my computer.
- [x] I have not attempted to bump, or alter versions.
- [ ] This is a documentation change.
- [x] This is a source change.
